### PR TITLE
Change Action name from "dagger-action" to "dagger-for-github"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Dagger Action'
+name: 'Dagger for GitHub'
 description: 'GitHub Action for Dagger, a programmable deployment system'
 author: 'dagger'
 branding:


### PR DESCRIPTION
For consistency purposes, the action name will now follow the repo name. That way, the marketplace will become: https://github.com/marketplace/actions/dagger-for-github, from the current: https://github.com/marketplace/actions/dagger-action

Signed-off-by: guillaume <guillaume.derouville@gmail.com>