### PR TITLE
add `project-update` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Following inputs can be used as `step.with` keys
 | `workdir`        | String  | `.`          | Working directory (below repository root)                        |
 | `install-only`   | Bool    | `false`      | Just install Dagger                                              |
 | `cleanup`        | Bool    | `true`       | Cleanup Dagger home folder at the end of a job                   |
-| `project-update` | Bool    | `false`      | Run `dagger project update` before running `args`                |
+| `project-update` | String  | `false`      | Run `dagger project update` before running `args`                |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Following inputs can be used as `step.with` keys
 | `workdir`        | String  | `.`          | Working directory (below repository root)                        |
 | `install-only`   | Bool    | `false`      | Just install Dagger                                              |
 | `cleanup`        | Bool    | `true`       | Cleanup Dagger home folder at the end of a job                   |
+| `project-update` | Bool    | `false`      | Run `dagger project update` before running `args`                |
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Cleanup Dagger home folder at the end of a job'
     default: 'true'
     required: false
+  project-update:
+    description: 'Run project update before args'
+    default: 'false'
+    required: false
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -212,7 +212,7 @@ function run() {
             if (inputs.projectUpdate && inputs.projectUpdate !== 'false') {
                 let command = `${daggerBin} project update`;
                 if (inputs.projectUpdate !== 'true')
-                    command += inputs.projectUpdate;
+                    command += ' ' + inputs.projectUpdate;
                 yield exec.exec(command);
             }
             stateHelper.setCleanup(inputs.cleanup);

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,7 +45,8 @@ function getInputs() {
             workdir: core.getInput('workdir') || '.',
             args: core.getInput('args'),
             installOnly: core.getBooleanInput('install-only'),
-            cleanup: core.getBooleanInput('cleanup')
+            cleanup: core.getBooleanInput('cleanup'),
+            projectUpdate: core.getBooleanInput('project-update')
         };
     });
 }
@@ -207,6 +208,9 @@ function run() {
             if (inputs.workdir && inputs.workdir !== '.') {
                 core.info(`Using ${inputs.workdir} as working directory`);
                 process.chdir(inputs.workdir);
+            }
+            if (inputs.projectUpdate) {
+                yield exec.exec(`${daggerBin} project update`);
             }
             stateHelper.setCleanup(inputs.cleanup);
             yield exec.exec(`${daggerBin} ${inputs.args} --log-format plain`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -46,7 +46,7 @@ function getInputs() {
             args: core.getInput('args'),
             installOnly: core.getBooleanInput('install-only'),
             cleanup: core.getBooleanInput('cleanup'),
-            projectUpdate: core.getBooleanInput('project-update')
+            projectUpdate: core.getInput('project-update')
         };
     });
 }
@@ -209,8 +209,11 @@ function run() {
                 core.info(`Using ${inputs.workdir} as working directory`);
                 process.chdir(inputs.workdir);
             }
-            if (inputs.projectUpdate) {
-                yield exec.exec(`${daggerBin} project update`);
+            if (inputs.projectUpdate && inputs.projectUpdate !== 'false') {
+                let command = `${daggerBin} project update`;
+                if (inputs.projectUpdate !== 'true')
+                    command += inputs.projectUpdate;
+                yield exec.exec(command);
             }
             stateHelper.setCleanup(inputs.cleanup);
             yield exec.exec(`${daggerBin} ${inputs.args} --log-format plain`);

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,7 +6,7 @@ export interface Inputs {
   args: string;
   installOnly: boolean;
   cleanup: boolean;
-  projectUpdate: boolean;
+  projectUpdate: string;
 }
 
 export async function getInputs(): Promise<Inputs> {
@@ -16,6 +16,6 @@ export async function getInputs(): Promise<Inputs> {
     args: core.getInput('args'),
     installOnly: core.getBooleanInput('install-only'),
     cleanup: core.getBooleanInput('cleanup'),
-    projectUpdate: core.getBooleanInput('project-update')
+    projectUpdate: core.getInput('project-update')
   };
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,7 @@ export interface Inputs {
   args: string;
   installOnly: boolean;
   cleanup: boolean;
+  projectUpdate: boolean;
 }
 
 export async function getInputs(): Promise<Inputs> {
@@ -14,6 +15,7 @@ export async function getInputs(): Promise<Inputs> {
     workdir: core.getInput('workdir') || '.',
     args: core.getInput('args'),
     installOnly: core.getBooleanInput('install-only'),
-    cleanup: core.getBooleanInput('cleanup')
+    cleanup: core.getBooleanInput('cleanup'),
+    projectUpdate: core.getBooleanInput('project-update')
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ async function run(): Promise<void> {
 
     if (inputs.projectUpdate && inputs.projectUpdate !== 'false') {
       let command = `${daggerBin} project update`;
-      if (inputs.projectUpdate !== 'true') command += inputs.projectUpdate;
+      if (inputs.projectUpdate !== 'true') command += ' ' + inputs.projectUpdate;
       await exec.exec(command);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,10 @@ async function run(): Promise<void> {
       process.chdir(inputs.workdir);
     }
 
-    if (inputs.projectUpdate) {
-      await exec.exec(`${daggerBin} project update`);
+    if (inputs.projectUpdate && inputs.projectUpdate !== 'false') {
+      let command = `${daggerBin} project update`;
+      if (inputs.projectUpdate !== 'true') command += inputs.projectUpdate;
+      await exec.exec(command);
     }
 
     stateHelper.setCleanup(inputs.cleanup);

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,10 @@ async function run(): Promise<void> {
       process.chdir(inputs.workdir);
     }
 
+    if (inputs.projectUpdate) {
+      await exec.exec(`${daggerBin} project update`);
+    }
+
     stateHelper.setCleanup(inputs.cleanup);
     await exec.exec(`${daggerBin} ${inputs.args} --log-format plain`);
   } catch (error) {


### PR DESCRIPTION
Add `project-update` flag, defaulting to `'false'`, to install deps before running `args`

Adding this flag would enable this action:
```yaml
    steps:
      - name: Checkout
        uses: actions/checkout@v2

      - name: dagger do test
        uses: dagger/dagger-for-github@v2
        with:
          install-only: true

      - run: dagger project update
      - run: dagger do test
```

to be like this:
```yaml
    steps:
      - name: Checkout
        uses: actions/checkout@v2

      - name: dagger do test
        uses: dagger/dagger-for-github@v2
        with:
          project-update: true
          args: do test
```

You can see this version running here:
https://github.com/joaofnds/ds/commit/76d0c94d675e4503db5f8ee8e3d05280a82032ac
https://github.com/joaofnds/ds/runs/5956403863?check_suite_focus=true#step:3:14

closes: #43