### PR TITLE
feat: add `cmds` input (multiline `args`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./
         with:
           version: ${{ matrix.version }}
-          args: do test
+          cmds: do test
           workdir: ./test/ci
 
   install-only:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
         name: Dagger
         uses: dagger/dagger-for-github@v2
         with:
-          args: do test
+          cmds: do test
 ```
 
 ### Install Only
@@ -60,6 +60,19 @@ steps:
     run: dagger version
 ```
 
+### Multiple commands
+
+```yaml
+steps:
+  -
+    name: Install Dagger
+    uses: dagger/dagger-for-github@v2
+    with:
+      cmds: |
+        project update
+        do test
+```
+
 ## Customizing
 
 ### inputs
@@ -69,7 +82,7 @@ Following inputs can be used as `step.with` keys
 | Name             | Type    | Default      | Description                                                      |
 |------------------|---------|--------------|------------------------------------------------------------------|
 | `version`        | String  | `latest`     | Dagger version                                                   |
-| `args`           | String  |              | Arguments to pass to Dagger                                      |
+| `cmds`           | String  |              | Commands to run on Dagger                                        |
 | `workdir`        | String  | `.`          | Working directory (below repository root)                        |
 | `install-only`   | Bool    | `false`      | Just install Dagger                                              |
 | `cleanup`        | Bool    | `true`       | Cleanup Dagger home folder at the end of a job                   |

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   args:
     description: 'Arguments to pass to Dagger'
     required: false
+    deprecationMessage: 'Use cmds input instead'
+  cmds:
+    description: 'Commands to run on Dagger'
+    required: false
   workdir:
     description: 'Working directory (below repository root)'
     default: '.'

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,7 @@ export interface Inputs {
   args: string;
   installOnly: boolean;
   cleanup: boolean;
+  cmds: string[];
 }
 
 export async function getInputs(): Promise<Inputs> {
@@ -14,7 +15,8 @@ export async function getInputs(): Promise<Inputs> {
     workdir: core.getInput('workdir') || '.',
     args: core.getInput('args'),
     installOnly: core.getBooleanInput('install-only'),
-    cleanup: core.getBooleanInput('cleanup')
+    cleanup: core.getBooleanInput('cleanup'),
+    cmds: await getInputList('cmds')
   };
 }
 


### PR DESCRIPTION
Add an input that allows for multiple dagger commands.

```yaml
      - name: dagger do test
        uses: dagger/dagger-for-github@v2
        with:
          cmds: |
            project update
            do test
```

The idea came from a [discussion](https://github.com/dagger/dagger-for-github/pull/44#discussion_r847403192) about how to run `dagger project update` before running other dagger commands within the same action step. Thanks @marcosnils and @crazy-max for [the idea](https://github.com/dagger/dagger-for-github/pull/44#discussion_r847800469) and for the comments (:

Here are some examples on how to use this command:
using just args: https://github.com/joaofnds/ds/actions/runs/2157832858
using args and cmds: https://github.com/joaofnds/ds/actions/runs/2157832072
using just cmds: https://github.com/joaofnds/ds/actions/runs/2157837793

I tried to make it backward compatible, so when you use `args` it just prints a warning and prepends `args` to `cmds`.

closes: https://github.com/dagger/dagger-for-github/issues/43