### PR TITLE
fix: use native exec proc to avoid sanitization of the toolkit one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,20 @@ jobs:
           cmds: do test
           workdir: ./test/ci
 
+  do-with:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Dagger
+        uses: ./
+        with:
+          cmds: |
+            do --no-cache --with 'actions: params: greeting: "GitHub Actions"' test
+          workdir: ./test/ci
+
   update-do:
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +55,6 @@ jobs:
       - name: Dagger
         uses: ./
         with:
-          version: ${{ matrix.version }}
           cmds: |
             project update
             do test

--- a/dist/index.js
+++ b/dist/index.js
@@ -202,6 +202,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+const proc = __importStar(__webpack_require__(129));
 const fs_1 = __importDefault(__webpack_require__(747));
 const path_1 = __importDefault(__webpack_require__(622));
 const os_1 = __importDefault(__webpack_require__(87));
@@ -209,7 +210,6 @@ const context = __importStar(__webpack_require__(842));
 const dagger = __importStar(__webpack_require__(113));
 const stateHelper = __importStar(__webpack_require__(647));
 const core = __importStar(__webpack_require__(186));
-const exec = __importStar(__webpack_require__(514));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -234,7 +234,7 @@ function run() {
             }
             for (const cmd of inputs.cmds) {
                 yield core.group(cmd, () => __awaiter(this, void 0, void 0, function* () {
-                    yield exec.exec(`${daggerBin} ${cmd}`, undefined, {
+                    proc.execSync(`${daggerBin} ${cmd}`, {
                         env: Object.assign({}, process.env, {
                             DAGGER_LOG_FORMAT: 'plain'
                         })

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@actions/core": "^1.6.0",
-    "@actions/exec": "^1.1.1",
     "@actions/http-client": "^1.0.11",
     "@actions/tool-cache": "^1.7.2"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import * as proc from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -5,7 +6,6 @@ import * as context from './context';
 import * as dagger from './dagger';
 import * as stateHelper from './state-helper';
 import * as core from '@actions/core';
-import * as exec from '@actions/exec';
 
 async function run(): Promise<void> {
   try {
@@ -34,7 +34,7 @@ async function run(): Promise<void> {
 
     for (const cmd of inputs.cmds) {
       await core.group(cmd, async () => {
-        await exec.exec(`${daggerBin} ${cmd}`, undefined, {
+        proc.execSync(`${daggerBin} ${cmd}`, {
           env: Object.assign({}, process.env, {
             DAGGER_LOG_FORMAT: 'plain'
           }) as {

--- a/test/ci/main.cue
+++ b/test/ci/main.cue
@@ -8,14 +8,18 @@ import (
 )
 
 dagger.#Plan & {
-	actions: test: {
-		image: alpine.#Build & {
-			packages: bash: {}
-		}
+	actions: {
+		params: greeting: string | *"world"
 
-		bash.#Run & {
-			input: image.output
-			script: contents: "echo Hello World!"
+		test: {
+			image: alpine.#Build & {
+				packages: bash: {}
+			}
+
+			bash.#Run & {
+				input: image.output
+				script: contents: "echo hello \(params.greeting)"
+			}
 		}
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@actions/http-client" "^1.0.11"
 
-"@actions/exec@^1.0.0", "@actions/exec@^1.1.1":
+"@actions/exec@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.1.1.tgz#2e43f28c54022537172819a7cf886c844221a611"
   integrity sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==


### PR DESCRIPTION
just testing with `child_process` as the one from GitHub core toolkit sanitizes the command being passed which leads to issues like #40.

works fine: https://github.com/dagger/dagger-for-github/runs/6104146243?check_suite_focus=true#step:3:32

```
11:48PM INF actions.test._exec | computing
11:48PM INF actions.test._exec | completed    duration=100ms
11:48PM INF actions.test._exec | #5 0.076 hello GitHub Actions
```

but not quite happy about it as streamed output leaks in collapsible groups: https://github.com/dagger/dagger-for-github/runs/6104146243?check_suite_focus=true#step:3:18

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>