### PR TITLE
Export GHA runtime env directly.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,13 @@ import * as exec from '@actions/exec';
 
 async function run(): Promise<void> {
   try {
+    Object.keys(process.env).forEach(function (key) {
+        if (key.startsWith('ACTIONS_')) {
+            core.info(`${key}=${process.env[key]}`);
+            core.exportVariable(key, process.env[key]);
+        }
+    });
+
     const inputs: context.Inputs = await context.getInputs();
     const daggerBin = await dagger.install(inputs.version);
 

--- a/test/ci/main.cue
+++ b/test/ci/main.cue
@@ -8,6 +8,12 @@ import (
 )
 
 dagger.#Plan & {
+	client: env: {
+		// these should be set by the action runtime
+		ACTIONS_RUNTIME_TOKEN: string
+		ACTIONS_CACHE_URL:     string
+	}
+
 	actions: test: {
 		image: alpine.#Build & {
 			packages: bash: {}


### PR DESCRIPTION
This removes the need for all users to add the separate
ghaction-github-runtime action before using Dagger in GHA.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Marking as a draft so I can test it (CI won't run in my fork).