### PR TITLE
ci: fix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,6 @@ jobs:
         uses: ./
         with:
           version: ${{ matrix.version }}
-          cmds: do test
-          workdir: ./test/ci
-
-  update-do:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Dagger
-        uses: ./
-        with:
-          version: ${{ matrix.version }}
           cmds: |
             project update
             do test
@@ -57,7 +45,9 @@ jobs:
         name: Dagger
         uses: ./
         with:
-          args: do test
+          cmds: |
+            project update
+            do test
           workdir: ./test/ci
 
   install-only:
@@ -100,5 +90,7 @@ jobs:
         uses: ./
         with:
           version: https://github.com/dagger/dagger.git#${{ matrix.ref }}
-          cmds: do test
+          cmds: |
+            project update
+            do test
           workdir: ./test/ci


### PR DESCRIPTION
Fixes issue in our e2e workflow:

```
 /opt/hostedtoolcache/dagger/0.2.9/x64/dagger do test
  failed to load plan: package "dagger.io" is incompatible with this version of dagger (requires 0.2.9 or newer). Run `dagger project update` to resolve this
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>