### PR TITLE
Install binary to a less permissive location by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
         # The install.sh script creates path ${prefix_dir}/bin
         cd "$prefix_dir" && { \
         curl -sL https://dl.dagger.io/dagger/install.sh 2>/dev/null | \
-        DAGGER_VERSION=${{ inputs.version }} sh 2>/dev/null; }
+        DAGGER_VERSION=${{ inputs.version }} sh; }
       shell: bash
 
     - run: |

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,8 @@ runs:
       env:
           INPUT_MODULE: ${{ inputs.module }}
 
-    - run: docker stop -t 300 $(docker ps --filter name="dagger-engine-*" -q)
+    - run: |
+        mapfile -t containers < <(docker ps --filter name="dagger-engine-*" -q)
+        docker stop -t 300 "${containers[@]}"
       shell: bash
       if: ${{ always() }}

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,15 @@ runs:
   using: "composite"
   steps:
     - run: |
-        cd /usr/local && { \
+        # Fallback to /usr/local for backwards compatability
+        prefix_dir="${RUNNER_TEMP:-/usr/local}"
+        # Ensure the dir is writable otherwise fallback to tmpdir
+        if [[ ! -d "$prefix_dir" ]] || [[ ! -w "$prefix_dir" ]]; then
+            prefix_dir="$(mktemp -d)"
+        fi
+        printf '%s/bin' "$prefix_dir" >> $GITHUB_PATH
+        # The install.sh script creates path ${prefix_dir}/bin
+        cd "$prefix_dir" && { \
         curl -sL https://dl.dagger.io/dagger/install.sh 2>/dev/null | \
         DAGGER_VERSION=${{ inputs.version }} sh 2>/dev/null; }
       shell: bash
@@ -41,7 +49,7 @@ runs:
     - run: |
         cd ${{ inputs.workdir }} && { \
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
-        /usr/local/bin/dagger \
+        dagger \
         ${{ inputs.dagger-flags }} \
         ${{ inputs.verb }} \
         ${INPUT_MODULE:+-m $INPUT_MODULE} \


### PR DESCRIPTION
I ran into a few issues when trying to run this action on self-hosted runners. 

The following changes were made and are backwards compatible:
- gracefully stop containers
  - Previously `docker stop` would still be executed even if there weren't any containers present
- install the dagger binary to a less permissive path
  - previously the action would fail to run since `/usr/local` wasn't writable by default
  - installs the binary to a temporary location that's accessible to the entire job/steps, then add that location to the `GITHUB_PATH`.