### PR TITLE
Update to 0.9.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 | Key           | Description                                               | Required | Default             |
 |---------------|-------------------------------------------------------------|----------|---------------------|
-| `version`     | Dagger Version                                              | false    | '0.9.3'             |
+| `version`     | Dagger Version                                              | false    | '0.9.11'             |
 | `dagger-flags`| Dagger CLI Flags                                            | false    | '--progress plain'  |
 | `verb`        | CLI verb (call, run, download, up, functions, shell, query) | false    | 'call'              |
 | `workdir`     | The working directory in which to run the Dagger CLI        | false    | '.'                 |

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Dagger Version'
     required: false
-    default: '0.9.5'
+    default: '0.9.11'
   dagger-flags:
     description: 'Dagger CLI Flags'
     required: false


### PR DESCRIPTION
- Update default dagger version to 0.9.11
- Fix wrong version in README.md