### PR TITLE
Bump default Dagger version to 0.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@
     verb: run
     args: node build.js
     cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-    version: "0.9.3"
+    version: "0.10.2"
 ```
 
 ### All `with:` input parameter options
 
-| Key           | Description                                               | Required | Default             |
-|---------------|-------------------------------------------------------------|----------|---------------------|
-| `version`     | Dagger Version                                              | false    | '0.9.3'             |
-| `dagger-flags`| Dagger CLI Flags                                            | false    | '--progress plain'  |
-| `verb`        | CLI verb (call, run, download, up, functions, shell, query) | false    | 'call'              |
-| `workdir`     | The working directory in which to run the Dagger CLI        | false    | '.'                 |
-| `cloud-token` | Dagger Cloud Token                                          | false    | ''                  |
-| `module`      | Dagger module to call. Local or Git                         | false    | ''                  |
-| `args`        | Arguments to pass to CLI                                    | false    | ''                  |
-| `engine-stop` | Whether to stop the Dagger Engine after this run            | false    | 'true'              |
+| Key             | Description                                                   | Required   | Default               |
+| --------------- | ------------------------------------------------------------- | ---------- | --------------------- |
+| `version`       | Dagger Version                                                | false      | '0.10.2'              |
+| `dagger-flags`  | Dagger CLI Flags                                              | false      | '--progress plain'    |
+| `verb`          | CLI verb (call, run, download, up, functions, shell, query)   | false      | 'call'                |
+| `workdir`       | The working directory in which to run the Dagger CLI          | false      | '.'                   |
+| `cloud-token`   | Dagger Cloud Token                                            | false      | ''                    |
+| `module`        | Dagger module to call. Local or Git                           | false      | ''                    |
+| `args`          | Arguments to pass to CLI                                      | false      | ''                    |
+| `engine-stop`   | Whether to stop the Dagger Engine after this run              | false      | 'true'                |

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Dagger Version'
     required: false
-    default: '0.9.5'
+    default: '0.10.2'
   dagger-flags:
     description: 'Dagger CLI Flags'
     required: false


### PR DESCRIPTION
This is scheduled to release later today, merge this afterwards.

## Follow-ups
- [ ] Tag `v5.2.0`