### PR TITLE
chore: bump default dagger version to v0.11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
     verb: run
     args: node build.js
     cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-    version: "0.11.1"
+    version: "0.11.2"
 ```
 
 ### Staying in sync with the `latest` version
@@ -35,7 +35,7 @@ By setting the version to `latest`, this action will install the latest version 
 
 | Key             | Description                                                   | Required   | Default               |
 | --------------- | ------------------------------------------------------------- | ---------- | --------------------- |
-| `version`       | Dagger Version                                                | false      | '0.11.1'              |
+| `version`       | Dagger Version                                                | false      | '0.11.2'              |
 | `dagger-flags`  | Dagger CLI Flags                                              | false      | '--progress plain'    |
 | `verb`          | CLI verb (call, run, download, up, functions, shell, query)   | false      | 'call'                |
 | `workdir`       | The working directory in which to run the Dagger CLI          | false      | '.'                   |

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Dagger Version'
     required: false
-    default: '0.11.1'
+    default: '0.11.2'
   dagger-flags:
     description: 'Dagger CLI Flags'
     required: false


### PR DESCRIPTION
Upgrades default dagger version to https://github.com/dagger/dagger/releases/tag/v0.11.2