### PR TITLE
fix(ux): increase readability of install step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
+    - shell: bash
+      run: |
+        set -o pipefail
         # Fallback to /usr/local for backwards compatability
         prefix_dir="${RUNNER_TEMP:-/usr/local}"
         # Ensure the dir is writable otherwise fallback to tmpdir
@@ -54,11 +56,13 @@ runs:
         fi
 
         # The install.sh script creates path ${prefix_dir}/bin
-        curl -fsS https://dl.dagger.io/dagger/install.sh | \
-        BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$VERSION sh; 
-      shell: bash
+        curl -fsS https://dl.dagger.io/dagger/install.sh \
+        | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$VERSION sh
 
-    - run: |
+    - shell: bash
+      env:
+        INPUT_MODULE: ${{ inputs.module }}
+      run: |
         cd ${{ inputs.workdir }} && { \
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
         dagger \
@@ -66,14 +70,11 @@ runs:
         ${{ inputs.verb }} \
         ${INPUT_MODULE:+-m $INPUT_MODULE} \
         ${{ inputs.args }}; }
-      shell: bash
-      env:
-        INPUT_MODULE: ${{ inputs.module }}
 
-    - run: |
+    - if: inputs.engine-stop == 'true'
+      shell: bash
+      run: |
         mapfile -t containers < <(docker ps --filter name="dagger-engine-*" -q)
         if [[ "${#containers[@]}" -gt 0 ]]; then
           docker stop -t 300 "${containers[@]}";
         fi
-      shell: bash
-      if: inputs.engine-stop == 'true'

--- a/action.yml
+++ b/action.yml
@@ -54,9 +54,8 @@ runs:
         fi
 
         # The install.sh script creates path ${prefix_dir}/bin
-        cd "$prefix_dir" && { \
-        curl -sL https://dl.dagger.io/dagger/install.sh 2>/dev/null | \
-        DAGGER_VERSION=$VERSION sh; }
+        curl -fsS https://dl.dagger.io/dagger/install.sh | \
+        BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$VERSION sh; 
       shell: bash
 
     - run: |


### PR DESCRIPTION
The official github self-hosted action container does not include curl in the OS but because the `curl` command in the GH Action's install step redirects stderr to /dev/null, it was hard to determine that.

As part of my Dagger interview, @gerhard and I investigated and found that issue. We changed the `curl` flags from `-sL` to `-fsS` to be more verbose with the error reporting and remove following redirects, as the move to Cloudfront obviated the need for that flag. We also (obviously) removed the stderr redirect to `/dev/null`

We also removed the subshell in the install step at the end because it was not needed and introduced extra complexity.

I could also see checking for the presence of curl at the beginning of the script and failing quickly with a message, but that was not discussed in the interview. Given that this happens very quickly and solves for other HTTP errors it doesn't seem particularly necessary but I could see the potential for it, if the desire for it was there.