### PR TITLE
feat: allow specifying nightly builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ By setting the version to `latest`, this action will install the latest version 
 | Key            | Description                                                 | Required | Default            |
 | -------------- | ----------------------------------------------------------- | -------- | ------------------ |
 | `version`      | Dagger Version                                              | false    | '0.13.5'           |
+| `commit`       | Dagger Dev Commit (overrides `version`)                     | false    | ''                 |
 | `dagger-flags` | Dagger CLI Flags                                            | false    | '--progress plain' |
 | `verb`         | CLI verb (call, run, download, up, functions, shell, query) | false    | 'call'             |
 | `workdir`      | The working directory in which to run the Dagger CLI        | false    | '.'                |

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Dagger Version"
     required: false
     default: "0.13.5"
+  commit:
+    description: "Dagger Dev Commit"
+    required: false
+    default: ""
   dagger-flags:
     description: "Dagger CLI Flags"
     required: false
@@ -55,9 +59,11 @@ runs:
           VERSION=
         fi
 
+        COMMIT=${{ inputs.commit }}
+
         # The install.sh script creates path ${prefix_dir}/bin
         curl -fsS https://dl.dagger.io/dagger/install.sh \
-        | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION=$VERSION sh
+        | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION="$VERSION" DAGGER_COMMIT="$COMMIT" sh
 
     - shell: bash
       env:


### PR DESCRIPTION
> [!WARNING]
>
> Needs testing!

The `version` field now accepts two additional fields:
- A sha1 git hash of a `main` commit
- The value `"head"` for the latest commit on `main`

This will allow users to put in nightly builds into their `action.yml`s, so that we can more easily allow testing with new versions of dagger.