### PR TITLE
test: add version tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,95 @@
+name: Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  # Enable manual trigger for easy debugging
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  version:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Use latest"
+        id: use-latest
+        uses: ./
+        with:
+          version: latest
+          verb: core
+          args: version
+      - name: "Use latest (check)"
+        run: |
+          target='${{ steps.use-latest.outputs.output }}'
+          if [[ "$target" =~ v[0-9]*\.[0-9]*\.[0-9]* ]]; then
+            echo "matches"
+            exit 0
+          else
+            echo "does not match"
+            exit 1
+          fi
+
+      - name: "Use v0.13.5"
+        id: use-v0-13-5
+        uses: ./
+        with:
+          version: v0.13.5
+          verb: core
+          args: version
+      - name: "Use v0.13.5 (check)"
+        run: |
+          target='${{ steps.use-v0-13-5.outputs.output }}'
+          if [[ "$target" =~ v0\.13\.5 ]]; then
+            echo "matches"
+            exit 0
+          else
+            echo "does not match"
+            exit 1
+          fi
+
+      - name: "Use commit"
+        id: use-commit
+        uses: ./
+        with:
+          commit: 540b4d1490f253054140f9249e823adf111e1c06
+          verb: core
+          args: version
+      - name: "Use commit (check)"
+        run: |
+          target='${{ steps.use-commit.outputs.output }}'
+          if [[ "$target" =~ v0\.13\.6-[0-9]+-540b4d1490f2 ]]; then
+            echo "matches"
+            exit 0
+          else
+            echo "does not match"
+            exit 1
+          fi
+
+      - name: "Use head"
+        id: use-head
+        uses: ./
+        with:
+          commit: head
+          verb: core
+          args: version
+      - name: "Use head (check)"
+        run: |
+          target='${{ steps.use-commit.outputs.output }}'
+          if [[ "$target" =~ v[0-9]*\.[0-9]*\.[0-9]*-[0-9]+-[0-9a-f]{12} ]]; then
+            echo "matches"
+            exit 0
+          else
+            echo "does not match"
+            exit 1
+          fi

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Whether to stop the Dagger Engine after this run"
     required: false
     default: "true"
+outputs:
+  output:
+    description: "Job output"
+    value: ${{ steps.exec.outputs.stdout }}
 runs:
   using: "composite"
   steps:
@@ -65,17 +69,21 @@ runs:
         curl -fsS https://dl.dagger.io/dagger/install.sh \
         | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION="$VERSION" DAGGER_COMMIT="$COMMIT" sh
 
-    - shell: bash
+    - id: exec
+      shell: bash
       env:
         INPUT_MODULE: ${{ inputs.module }}
       run: |
+        tmpout=$(mktemp)
         cd ${{ inputs.workdir }} && { \
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
         dagger \
         ${{ inputs.dagger-flags }} \
         ${{ inputs.verb }} \
         ${INPUT_MODULE:+-m $INPUT_MODULE} \
-        ${{ inputs.args }}; }
+        ${{ inputs.args }}; } | tee "${tmpout}"
+
+        (echo -n "stdout=" && cat "${tmpout}") >> "$GITHUB_OUTPUT"
 
     - if: inputs.engine-stop == 'true'
       shell: bash


### PR DESCRIPTION
This PR adds some basic versioning tests to confirm the new behavior added in #151. 

To do this, we add outputs to the action to be able to easily capture the stdout of the call to the `dagger` binary.

Then we can add some github workflows to check that the version parameter is working as desired.

You can see an example run in https://github.com/jedevc/dagger-for-github/actions/runs/11331238930/job/31510817051.