### PR TITLE
Alias args to call and make call optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,3 +113,12 @@ jobs:
             echo "does not match"
             exit 1
           fi
+  nocall:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Only Install"
+        uses: ./
+      - name: "Test Install"
+        run: |
+          dagger core version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,3 +93,19 @@ jobs:
             echo "does not match"
             exit 1
           fi
+      - name: "Test call"
+        id: test-call
+        uses: ./
+        with:
+          module: github.com/shykes/daggerverse/hello@v0.3.0
+          call: hello
+      - name: "Test call (check)"
+        run: |
+          target='${{ steps.test-call.outputs.output }}'
+          if [[ "$target" == "hello, world!" ]]; then
+            echo "matches"
+            exit 0
+          else
+            echo "does not match"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,10 @@ jobs:
             echo "does not match"
             exit 1
           fi
+  call:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
       - name: "Test call"
         id: test-call
         uses: ./

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@
 - name: Hello
   uses: dagger/dagger-for-github@v6
   with:
-    verb: call
     module: github.com/shykes/daggerverse/hello
-    args: hello --greeting Hola --name Jeremy
+    call: hello --greeting Hola --name Jeremy
     cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 ```
 
@@ -43,4 +42,5 @@ By setting the version to `latest`, this action will install the latest version 
 | `cloud-token`  | Dagger Cloud Token                                          | false    | ''                 |
 | `module`       | Dagger module to call. Local or Git                         | false    | ''                 |
 | `args`         | Arguments to pass to CLI                                    | false    | ''                 |
+| `call`         | Arguments to pass to CLI (Alias for args)                   | false    | ''                 |
 | `engine-stop`  | Whether to stop the Dagger Engine after this run            | false    | 'true'             |

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
       run: |
         tmpout=$(mktemp)
         ARGS="${{ inputs.args }}"
-        ARGS="${INPUT_ARGS:-"${{ inputs.call }}"}"
+        ARGS="${ARGS:-"${{ inputs.call }}"}"
         cd ${{ inputs.workdir }} && { \
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
         dagger \

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
         INPUT_MODULE: ${{ inputs.module }}
       run: |
         tmpout=$(mktemp)
-        INPUT_ARGS="${ INPUT_ARGS:-INPUT_CALL }"
+        INPUT_ARGS="${INPUT_ARGS:-INPUT_CALL}"
         cd ${{ inputs.workdir }} && { \
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
         dagger \

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Whether to stop the Dagger Engine after this run"
     required: false
     default: "true"
+  call:
+    description: "Function and arguments for dagger call"
+    required: false
+    default: ""
 outputs:
   output:
     description: "Job output"
@@ -70,22 +74,24 @@ runs:
         | BIN_DIR=${prefix_dir}/bin DAGGER_VERSION="$VERSION" DAGGER_COMMIT="$COMMIT" sh
 
     - id: exec
+      if: inputs.call != '' || inputs.args != ''
       shell: bash
       env:
         INPUT_MODULE: ${{ inputs.module }}
       run: |
         tmpout=$(mktemp)
+        INPUT_ARGS="${ INPUT_ARGS:-INPUT_CALL }"
         cd ${{ inputs.workdir }} && { \
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
         dagger \
         ${{ inputs.dagger-flags }} \
         ${{ inputs.verb }} \
         ${INPUT_MODULE:+-m $INPUT_MODULE} \
-        ${{ inputs.args }}; } | tee "${tmpout}"
+        $INPUT_ARGS; } | tee "${tmpout}"
 
         (echo -n "stdout=" && cat "${tmpout}") >> "$GITHUB_OUTPUT"
 
-    - if: inputs.engine-stop == 'true'
+    - if: (inputs.call != '' || inputs.args != '') && inputs.engine-stop == 'true'
       shell: bash
       run: |
         mapfile -t containers < <(docker ps --filter name="dagger-engine-*" -q)

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
         INPUT_MODULE: ${{ inputs.module }}
       run: |
         tmpout=$(mktemp)
-        INPUT_ARGS="${INPUT_ARGS:-INPUT_CALL}"
+        INPUT_ARGS="${INPUT_ARGS:-$INPUT_CALL}"
         cd ${{ inputs.workdir }} && { \
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
         dagger \

--- a/action.yml
+++ b/action.yml
@@ -80,14 +80,15 @@ runs:
         INPUT_MODULE: ${{ inputs.module }}
       run: |
         tmpout=$(mktemp)
-        INPUT_ARGS="${INPUT_ARGS:-$INPUT_CALL}"
+        ARGS="${{ inputs.args }}"
+        ARGS="${INPUT_ARGS:-"${{ inputs.call }}"}"
         cd ${{ inputs.workdir }} && { \
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
         dagger \
         ${{ inputs.dagger-flags }} \
         ${{ inputs.verb }} \
         ${INPUT_MODULE:+-m $INPUT_MODULE} \
-        $INPUT_ARGS; } | tee "${tmpout}"
+        $ARGS; } | tee "${tmpout}"
 
         (echo -n "stdout=" && cat "${tmpout}") >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Discussed in person. We'd like to:
- Make args optional, so if I don't pass args (or call) we can just use the action to install dagger and run `dagger call foo` in bash steps manually
- alias `call` to `args` so that we can say `call: hello` instead of `args: hello`