### PR TITLE
fix: Action now parses "\" line seperator

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,13 +79,23 @@ runs:
         INPUT_MODULE: ${{ inputs.module }}
       run: |
         tmpout=$(mktemp)
-        cd ${{ inputs.workdir }} && { \
+        cd ${{ inputs.workdir }}
+
+        # Preprocess args: replace backslash-newline with space, then split into array
+        if [[ -n "${{ inputs.args }}" ]]; then
+          ARGS=$(echo "${{ inputs.args }}" | awk '{sub(/[ \t]*\\$/, ""); printf "%s", $0; if (!/[ \t]*\\$/) print ""}')
+          read -r -a ARGS_ARRAY <<< "$ARGS"
+        else
+          ARGS_ARRAY=()
+        fi
+
         DAGGER_CLOUD_TOKEN=${{ inputs.cloud-token }} \
         dagger \
         ${{ inputs.dagger-flags }} \
         ${{ inputs.verb }} \
         ${INPUT_MODULE:+-m $INPUT_MODULE} \
-        ${{ inputs.args || inputs.call }}; } | tee "${tmpout}"
+        "${ARGS_ARRAY[@]}" \
+        ${{ inputs.call }} | tee "${tmpout}"
 
         {
           # we need a delim that doesn't appear in the output - a hash of the


### PR DESCRIPTION
When trying to use this action I tried to provide multi-line args to my call command, for example:

```yaml
      - name: Run Something
        uses: dagger/dagger-for-github@v7
        env:
         API_TOKEN: ${{ steps.set-token.outputs.api_token }}
        with:
          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN}}
          version: "latest"
          verb: call
          args: some-command \
            --token=env:API_TOKEN \
            --progress=plain

Which was resulting in a very perplexing error regarding required flags even when I could copy/paste the exact command from actions into my local CLI and run it fine:

```
Error: required flag(s) "token" not set
```

I realized that the `with.args` was wanting all of the args to sit on the same line and the `\` separator was breaking the interpretation of those args.

So I updated the arg parsing in the bash in the action to support this use case.  You can run this example to simulate the action input and the result:

```bash
#!/usr/bin/env bash

# Example: Simulate receiving multi-line args (as a single string)
ARGS_INPUT="--foo bar \
--baz qux \
--flag"

# Remove backslash-newline and any trailing spaces, do not include backslash in args
ARGS=$(echo "$ARGS_INPUT" | awk '{sub(/[ \t]*\\$/, ""); printf "%s", $0; if (!/[ \t]*\\$/) print ""}')

# Convert to array
read -r -a ARGS_ARRAY <<< "$ARGS"

# Show the resulting array
echo "Parsed arguments:"
for arg in "${ARGS_ARRAY[@]}"; do
  echo "[$arg]"
done

echo "Result: dagger call some-call-command ${ARGS_ARRAY[@]}"
```

For example:

```
./bash-example.sh
Parsed arguments:
[--foo]
[bar]
[--baz]
[qux]
[--flag]
Result: dagger call some-call-command --foo bar --baz qux --flag
```

